### PR TITLE
GitHub runner fuckery2

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner.nix
+++ b/nixos/modules/services/continuous-integration/github-runner.nix
@@ -120,13 +120,7 @@ in
         RUNNER_ROOT = runtimeDir;
       };
 
-      path = (with pkgs; [
-        bash
-        coreutils
-        git
-        gnutar
-        gzip
-      ]) ++ [
+      path = [
         config.nix.package
       ] ++ cfg.extraPackages;
 

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.280.1";
+  version = "2.280.2";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "4d17f77f5e8d552740a91ce2868fd05ff5a0dfee";
-    sha256 = "sha256:0ag18a8m6ymk0r2g1fn37332jsm3dw9qykc52k2qd6ykzhpigjvb";
+    rev = "ccafb91bfbcee5bed530aa82a1a0381b2c8f260c";
+    sha256 = "sha256:01g7ljczngmxndv6qgriafvjig919zvzp7h3lhlcmlyk600jyb12";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.279.0";
+  version = "2.280.1";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -84,8 +84,10 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "actions";
     repo = "runner";
-    rev = "6b75179ec79e2041b3b5b4e9206b73db2d206aac"; # v${version}
-    sha256 = "sha256-d7LAHL8Ff7R++d1HuLxWjtiBZRogySe7xHY/xJAcFms=";
+    # v${version} would be better but causes nuget to barf,
+    # so hash version of the tag instead.
+    rev = "4d17f77f5e8d552740a91ce2868fd05ff5a0dfee";
+    sha256 = "sha256:0ag18a8m6ymk0r2g1fn37332jsm3dw9qykc52k2qd6ykzhpigjvb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.280.3";
+  version = "2.281.1";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "409920e9f03bd38fe6e58807f069394993ce32e4";
-    sha256 = "sha256:0h13jlr6pah6sdndv4l53fc5hxk0n4ds87jvv61mvpjmdh9rx8xv";
+    rev = "c8caf59bb7adaa87c4cf8f61372670d338a13f2d";
+    sha256 = "sha256:1v81mrqxdcfwxzvd9d71brn9kjhi1zgalqa582fmly9h7i54ap9n";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.280.2";
+  version = "2.280.3";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "ccafb91bfbcee5bed530aa82a1a0381b2c8f260c";
-    sha256 = "sha256:01g7ljczngmxndv6qgriafvjig919zvzp7h3lhlcmlyk600jyb12";
+    rev = "409920e9f03bd38fe6e58807f069394993ce32e4";
+    sha256 = "sha256:0h13jlr6pah6sdndv4l53fc5hxk0n4ds87jvv61mvpjmdh9rx8xv";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.281.1";
+  version = "2.283.1";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "c8caf59bb7adaa87c4cf8f61372670d338a13f2d";
-    sha256 = "sha256:1v81mrqxdcfwxzvd9d71brn9kjhi1zgalqa582fmly9h7i54ap9n";
+    rev = "e6baf0d2755bc747d0eb58f24941e273d16c6524";
+    sha256 = "sha256-S4Mql8lyHxahhYGoo91mlN6DrwKhyj1em0dv561j2l8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.285.0";
+  version = "2.285.1";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "c75a77df668b81fa8d517fda2bb20b4f96dd9d6e";
-    sha256 = "sha256-vlipA1ovVkBrwpZ8B0bMEykBMUwOaYzV+/FxY9kT6Z4=";
+    rev = "50afba61b40932c1084e31b5e9e7f5af325cc2ac";
+    sha256 = "sha256-SlKUuebsoZ9OgYuDTNOlY1KMg01LFSFazrLCctiFq3A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.284.0";
+  version = "2.285.0";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "9027c154d05776c16f6df6c0345bc9ec20440ebe";
-    sha256 = "sha256-JR0OzbT5gGhO/dxb/eSjP/d/VxW/aLmTs/oPwN8b8Rc=";
+    rev = "c75a77df668b81fa8d517fda2bb20b4f96dd9d6e";
+    sha256 = "sha256-vlipA1ovVkBrwpZ8B0bMEykBMUwOaYzV+/FxY9kT6Z4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.283.3";
+  version = "2.284.0";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "844595b1b3f2b73aa4aa94025326fc0a8c0ca780";
-    sha256 = "sha256-B2dn3AIGk+xMFqRsKv4pvlZ6K4xySsS0klk8vN8giso=";
+    rev = "9027c154d05776c16f6df6c0345bc9ec20440ebe";
+    sha256 = "sha256-JR0OzbT5gGhO/dxb/eSjP/d/VxW/aLmTs/oPwN8b8Rc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -20,7 +20,7 @@
 }:
 let
   pname = "github-actions-runner";
-  version = "2.283.1";
+  version = "2.283.3";
 
   deps = (import ./deps.nix { inherit fetchurl; });
   nugetPackages = map
@@ -86,8 +86,8 @@ stdenv.mkDerivation rec {
     repo = "runner";
     # v${version} would be better but causes nuget to barf,
     # so hash version of the tag instead.
-    rev = "e6baf0d2755bc747d0eb58f24941e273d16c6524";
-    sha256 = "sha256-S4Mql8lyHxahhYGoo91mlN6DrwKhyj1em0dv561j2l8=";
+    rev = "844595b1b3f2b73aa4aa94025326fc0a8c0ca780";
+    sha256 = "sha256-B2dn3AIGk+xMFqRsKv4pvlZ6K4xySsS0klk8vN8giso=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
update the github runner manually.

for next time.

if we keep github runners, then using a shell script that generates a nix override might be 'fun'.

or switch over to hercules-ci , so we can do away with github runners and the extra complexity it gives (with X amount of systemd nspawn containters).

or use hercules-ci to automatically deploy the new github runners on a change to nixpkgs.

just ideas!

