### PR TITLE
Fix HOME being changed

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -13,6 +13,7 @@ npmConfigHook() {
 
     echo "Configuring npm"
 
+    local old_home="$HOME"
     export HOME="$TMPDIR"
     export npm_config_nodedir="@nodeSrc@"
     export npm_config_node_gyp="@nodeGyp@"
@@ -115,6 +116,7 @@ npmConfigHook() {
     fi
 
     echo "Finished npmConfigHook"
+    export HOME="$old_home"
 }
 
 postPatchHooks+=(npmConfigHook)

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 
 npmInstallHook() {
+    export HOME="$TMPDIR"
     echo "Executing npmInstallHook"
 
     runHook preInstall


### PR DESCRIPTION
Context: there is desire to use pkgs.npmHooks.npmConfigHook in a nix shell

This fixes* HOME being set to another value and messing up your environment.

It should be noted that the npm-insall-hook seems to rely on the variable being changed in the npm-config-hook, as without changing it back in the npm-install-hook, typescript (and probably many more packages) failed to build.

Q: What about the exits? You don't set HOME back on failure. A: `exit` will quit out of the nix shell, so we don't need to worry about it

*The change I made to npm-install-hook was just the first thing I tried, and it worked for my project, but it may be a bad solution, and break other things.